### PR TITLE
Allow github-pages to deploy on tags

### DIFF
--- a/otterdog/eclipse-syson.jsonnet
+++ b/otterdog/eclipse-syson.jsonnet
@@ -69,7 +69,8 @@ orgs.newOrg('eclipse-syson') {
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "main"
+            "main",
+            "v*"
           ],
           deployment_branch_policy: "selected",
         },


### PR DESCRIPTION
- avoid error message of type "Tag vYYYY.MM.XX is not allowed to deploy to github-pages due to environment protection rules."